### PR TITLE
fix: azure file path

### DIFF
--- a/azureblob/azure.go
+++ b/azureblob/azure.go
@@ -246,5 +246,5 @@ func (client Client) GetEndpoint() string {
 	if client.Config.Endpoint != "" {
 		return client.Config.Endpoint
 	}
-	return client.containerURL.String()
+	return fmt.Sprintf(blobFormatString, client.Config.AccessId)
 }


### PR DESCRIPTION
Fixed file path concatenation error when domain name returned to Casdoor without CDN domain name.