### PR TITLE
fix: check endpoint prefix in qiniu.go

### DIFF
--- a/qiniu/qiniu.go
+++ b/qiniu/qiniu.go
@@ -77,6 +77,10 @@ func New(config *Config) (*Client, error) {
 	if len(config.Endpoint) == 0 {
 		return nil, fmt.Errorf("endpoint must be provided.")
 	}
+	// 检查Endpoint是否以http://或https://开头
+	if !strings.HasPrefix(config.Endpoint, "http://") && !strings.HasPrefix(config.Endpoint, "https://") {
+		return nil, fmt.Errorf("endpoint must start with http:// or https://")
+	}
 	client.storageCfg.UseHTTPS = config.UseHTTPS
 	client.storageCfg.UseCdnDomains = config.UseCdnDomains
 	client.bucketManager = storage.NewBucketManager(client.mac, &client.storageCfg)

--- a/qiniu/qiniu.go
+++ b/qiniu/qiniu.go
@@ -77,7 +77,7 @@ func New(config *Config) (*Client, error) {
 	if len(config.Endpoint) == 0 {
 		return nil, fmt.Errorf("endpoint must be provided.")
 	}
-	// 检查Endpoint是否以http://或https://开头
+
 	if !strings.HasPrefix(config.Endpoint, "http://") && !strings.HasPrefix(config.Endpoint, "https://") {
 		return nil, fmt.Errorf("endpoint must start with http:// or https://")
 	}

--- a/qiniu/qiniu.go
+++ b/qiniu/qiniu.go
@@ -92,7 +92,7 @@ func (client Client) SetPutPolicy(putPolicy *storage.PutPolicy) {
 func (client Client) Get(path string) (file *os.File, err error) {
 	readCloser, err := client.GetStream(path)
 
-	if file, err = ioutil.TempFile("/tmp", "qiniu"); err == nil {
+	if file, err = ioutil.TempFile(os.TempDir(), "qiniu"); err == nil {
 		defer readCloser.Close()
 		_, err = io.Copy(file, readCloser)
 		file.Seek(0, 0)


### PR DESCRIPTION
Ensure the configuration's endpoint starts with either 'http://' or 'https://'. This validation check prevents errors related to invalid endpoint formats, enhancing the robustness of the connection setup process.
